### PR TITLE
Statically condense boundary conditions

### DIFF
--- a/ssc/libssc.c
+++ b/ssc/libssc.c
@@ -1088,9 +1088,12 @@ static PetscErrorCode PCPatchCreateMatrix(PC pc, PetscInt which, Mat *mat)
             const PetscInt *idx = dofsArray + (offset + c)*patch->totalDofsPerCell;
             for (PetscInt i = 0; i < patch->totalDofsPerCell; i++) {
                 const PetscInt row = idx[i];
+                if (row < 0) continue;
                 for (PetscInt j = 0; j < patch->totalDofsPerCell; j++) {
                     const PetscInt col = idx[j];
                     const PetscInt key = row*rsize + col;
+                    if (col < 0) continue;
+
                     if (!PetscBTLookupSet(bt, key)) {
                         ++dnnz[row];
                     }

--- a/ssc/libssc.c
+++ b/ssc/libssc.c
@@ -1357,6 +1357,10 @@ static PetscErrorCode PCApply_PATCH(PC pc, Vec x, Vec y)
     ierr = ISRestoreIndices(patch->globalBcNodes, &bcNodes); CHKERRQ(ierr);
     ierr = VecRestoreArrayRead(x, &globalX); CHKERRQ(ierr);
     ierr = VecRestoreArray(y, &globalY); CHKERRQ(ierr);
+    if (patch->partition_of_unity) {
+        /* Now apply partition of unity */
+        ierr = VecPointwiseMult(y, y, patch->dof_weights); CHKERRQ(ierr);
+    }
 
     ierr = PetscOptionsPopGetViewerOff(); CHKERRQ(ierr);
     ierr = PetscLogEventEnd(PC_Patch_Apply, pc, 0, 0, 0); CHKERRQ(ierr);

--- a/ssc/libssc.c
+++ b/ssc/libssc.c
@@ -754,7 +754,7 @@ static PetscErrorCode PCPatchCreateCellPatchDiscretisationInfo(PC pc)
 
                         /* first, check if this is either a globally enforced or locally enforced BC dof */
                         PetscHashIMap(globalBcs, globalDof + l, isGlobalBcDof);
-                        PetscHashIMap(globalBcs, globalDof + l, isArtificialBcDof);
+                        PetscHashIMap(artificialbcs, globalDof + l, isArtificialBcDof);
 
                         /* if it's either, don't ever give it a local dof number */
                         if (isGlobalBcDof >= 0 || isArtificialBcDof >= 0) {


### PR DESCRIPTION
For a representative 3d run, reduces solver time on my machine from 2.5 min to 0.9 min, and peak memory usage from 110GB to 12GB.